### PR TITLE
refactor: use only one metric with labels

### DIFF
--- a/src/op-metrics/database.ts
+++ b/src/op-metrics/database.ts
@@ -6,6 +6,7 @@ export enum NETWORK_TYPE {
   ETHEREUM = 'ETHEREUM',
   BINANCE = 'BINANCE',
   ARBITRUM = 'ARBITRUM',
+  HARMONY = 'HARMONY',
 }
 
 export enum OPERATION_TYPE {

--- a/src/op-metrics/op-metrics.module.ts
+++ b/src/op-metrics/op-metrics.module.ts
@@ -9,28 +9,9 @@ import { makeGaugeProvider } from '@willsoto/nestjs-prometheus';
   providers: [
     OperationsMetricsService,
     makeGaugeProvider({
-      name: 'operations_hmy_to_eth_success_gauge',
-      help: 'Harmony to Ethereum success operations count',
-    }),
-    makeGaugeProvider({
-      name: 'operations_hmy_to_bsc_success_gauge',
-      help: 'Harmony to Bsc success operations count',
-    }),
-    makeGaugeProvider({
-      name: 'operations_hmy_to_arb_success_gauge',
-      help: 'Harmony to Arbitrum success operations count',
-    }),
-    makeGaugeProvider({
-      name: 'operations_eth_to_hmy_success_gauge',
-      help: 'Ethereum to Harmony success operations count',
-    }),
-    makeGaugeProvider({
-      name: 'operations_bsc_to_hmy_success_gauge',
-      help: 'Bsc to Harmony success operations count',
-    }),
-    makeGaugeProvider({
-      name: 'operations_arb_to_hmy_success_gauge',
-      help: 'Arbitrum to Harmony success operations count',
+      name: 'lzevent_operations_success',
+      help: 'successful operations',
+      labelNames: ['from', 'to'],
     }),
   ],
   exports: [OperationsMetricsService],

--- a/src/op-metrics/op-metrics.service.ts
+++ b/src/op-metrics/op-metrics.service.ts
@@ -3,12 +3,6 @@ import { Gauge } from 'prom-client';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { DBService, NETWORK_TYPE, OPERATION_TYPE, STATUS } from './database';
 
-enum CHAIN {
-  BSC = 'bsc',
-  ETH = 'eth',
-  HMY = 'hmy',
-}
-
 @Injectable()
 export class OperationsMetricsService {
   private readonly logger = new Logger(OperationsMetricsService.name);
@@ -16,18 +10,8 @@ export class OperationsMetricsService {
   private syncInterval = 1000 * 30;
 
   constructor(
-    @InjectMetric('operations_hmy_to_eth_success_gauge')
-    public hmyToEthSuccessGauge: Gauge<string>,
-    @InjectMetric('operations_hmy_to_bsc_success_gauge')
-    public hmyToBscSuccessGauge: Gauge<string>,
-    @InjectMetric('operations_hmy_to_arb_success_gauge')
-    public hmyToArbSuccessGauge: Gauge<string>,
-    @InjectMetric('operations_eth_to_hmy_success_gauge')
-    public ethToHmySuccessGauge: Gauge<string>,
-    @InjectMetric('operations_bsc_to_hmy_success_gauge')
-    public bscToHmySuccessGauge: Gauge<string>,
-    @InjectMetric('operations_arb_to_hmy_success_gauge')
-    public arbToHmySuccessGauge: Gauge<string>,
+    @InjectMetric('lzevent_operations_success')
+    public successGauge: Gauge<string>,
   ) {
     this.database = new DBService();
 
@@ -35,12 +19,11 @@ export class OperationsMetricsService {
   }
 
   updateCounterByConfig = async (params: {
-    counter: Gauge<string>;
     type: OPERATION_TYPE;
     network: NETWORK_TYPE;
     status: STATUS;
   }) => {
-    const { counter, type, network, status } = params;
+    const { type, network, status } = params;
 
     const newCount = await this.database.getOperationsCount({
       type,
@@ -48,7 +31,11 @@ export class OperationsMetricsService {
       status,
     });
 
-    counter.set(newCount);
+    const from =
+      type == OPERATION_TYPE.ONE_ETH ? NETWORK_TYPE.HARMONY : network;
+    const to = type == OPERATION_TYPE.ETH_ONE ? NETWORK_TYPE.HARMONY : network;
+
+    this.successGauge.set({ from, to }, newCount);
   };
 
   updateCounters = async () => {
@@ -57,42 +44,36 @@ export class OperationsMetricsService {
         type: OPERATION_TYPE.ONE_ETH,
         network: NETWORK_TYPE.ETHEREUM,
         status: STATUS.SUCCESS,
-        counter: this.hmyToEthSuccessGauge,
       });
 
       await this.updateCounterByConfig({
         type: OPERATION_TYPE.ONE_ETH,
         network: NETWORK_TYPE.BINANCE,
         status: STATUS.SUCCESS,
-        counter: this.hmyToBscSuccessGauge,
       });
 
       await this.updateCounterByConfig({
         type: OPERATION_TYPE.ONE_ETH,
         network: NETWORK_TYPE.ARBITRUM,
         status: STATUS.SUCCESS,
-        counter: this.hmyToArbSuccessGauge,
       });
 
       await this.updateCounterByConfig({
         type: OPERATION_TYPE.ETH_ONE,
         network: NETWORK_TYPE.ETHEREUM,
         status: STATUS.SUCCESS,
-        counter: this.ethToHmySuccessGauge,
       });
 
       await this.updateCounterByConfig({
         type: OPERATION_TYPE.ETH_ONE,
         network: NETWORK_TYPE.BINANCE,
         status: STATUS.SUCCESS,
-        counter: this.bscToHmySuccessGauge,
       });
 
       await this.updateCounterByConfig({
         type: OPERATION_TYPE.ETH_ONE,
         network: NETWORK_TYPE.ARBITRUM,
         status: STATUS.SUCCESS,
-        counter: this.arbToHmySuccessGauge,
       });
     } catch (e) {
       this.logger.error('updateCounters error', e);


### PR DESCRIPTION
instead of having one metric per network pair we leverage the power of labels, this way we have more flexibility when it comes to creating dashboard and alerts 